### PR TITLE
Add CALC style guide

### DIFF
--- a/src/docs/02-reference.md
+++ b/src/docs/02-reference.md
@@ -13,5 +13,8 @@ A group of open-source UI components and visual styles to create beautiful, cons
 ## [Federal Election Commision Website Styleguide](https://pages.18f.gov/fec-style/)
 Shared styles and user interface components for the betaFEC website.
 
+## [CALC Style Guide](https://calc-dev.apps.cloud.gov/styleguide/)
+Shared styles and user interface components for CALC.
+
 ## [Glossary](https://github.com/18F/glossary)
 A glossary panel component for your site to help readers understand jargon


### PR DESCRIPTION
This adds the [CALC Style Guide](https://calc-dev.apps.cloud.gov/styleguide/). Note that it will eventually be hosted at calc.gsa.gov, but due to ATO issues it's currently only at calc-dev.apps.cloud.gov.
