### PR TITLE
Build Sass/SCSS entry points

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -2,6 +2,11 @@
 
 const fractal = module.exports = require('@frctl/fractal').create();
 
+const sass = require('./lib/sass');
+
+// XXX detect the CLI command
+const command = process.argv[2];
+
 const src = __dirname + '/src';
 
 fractal.set('project.title', 'Marigold');
@@ -21,11 +26,6 @@ fractal.web.set('static.path', src + '/assets');
 fractal.web.set('static.mount', 'assets');
 
 fractal.web.set('builder.dest', __dirname + '/build');
-
-const sass = require('./lib/sass');
-
-// XXX detect the CLI command
-const command = process.argv[2];
 
 if (command === 'build') {
   sass.buildDirectory(src);

--- a/fractal.js
+++ b/fractal.js
@@ -2,14 +2,14 @@
 
 const fractal = module.exports = require('@frctl/fractal').create();
 
+const src = __dirname + '/src';
+
 fractal.set('project.title', 'Marigold');
 
 // use Nunjucks as the templating engine
 fractal.components.engine(require('@frctl/nunjucks')({
   filters: require('./lib/template-filters')
 }));
-
-const src = __dirname + '/src';
 
 fractal.components.set('ext', '.njk');
 fractal.components.set('path', src + '/components');
@@ -21,3 +21,14 @@ fractal.web.set('static.path', src + '/assets');
 fractal.web.set('static.mount', 'assets');
 
 fractal.web.set('builder.dest', __dirname + '/build');
+
+const sass = require('./lib/sass');
+
+// XXX detect the CLI command
+const command = process.argv[2];
+
+if (command === 'build') {
+  sass.buildDirectory(src);
+} else if (command === 'start') {
+  sass.watchDirectory(src);
+}

--- a/lib/sass.js
+++ b/lib/sass.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const Path = require('path');
+const chokidar = require('chokidar');
+const fs = require('fs');
+const fse = require('fs-extra');
+const anymatch = require('anymatch');
+const sass = require('node-sass');
+
+const log = console;
+
+const includePattern = '**/*.scss';
+const excludePattern = [
+  '_*.scss',
+  'node_modules/*'
+];
+
+const isEntrypoint = (filename) => {
+  return anymatch(includePattern, filename)
+      && !anymatch(excludePattern, filename);
+};
+
+const sassOptions = {
+  includePaths: [
+    Path.join(__dirname, '../node_modules/uswds/src/stylesheets')
+  ]
+};
+
+const buildFile = (path) => {
+  const opts = Object.assign({
+    file: path,
+    outFile: path.replace(/\.scss$/, '.css'),
+  }, sassOptions);
+
+  return new Promise((resolve, reject) => {
+    log.log('[sass] rendering:', opts.file, '=>', opts.outFile);
+    sass.render(opts, (error, result) => {
+      if (error) {
+        log.error('[sass] render error:', error);
+        reject(error);
+      } else {
+        fs.writeFile(opts.outFile, result.css, (error) => {
+          if (error) {
+            log.error('[sass] write error:', error);
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      }
+    });
+  });
+};
+
+const buildDirectory = (path) => {
+  const match = (item) => isEntrypoint(item.path);
+
+  return new Promise(resolve => {
+    const paths = [];
+    log.log('[sass] building files in:', path);
+    fse.walk(path)
+      .on('data', item => {
+        if (match(item)) {
+          buildFile(item.path);
+          paths.push(item.path);
+        }
+      })
+      .on('end', () => {
+        log.log('[sass] built %d files', paths.length);
+        resolve(paths);
+      });
+  });
+};
+
+const watchDirectory = (path) => {
+  const src = Path.join(path, includePattern);
+  log.log('[sass] watching for changes in:', src);
+  return chokidar
+    .watch(src, {
+      ignored: excludePattern
+    })
+    .on('add',    file => buildFile(file))
+    .on('change', file => buildFile(file))
+    .on('unlink', file => fs.unlinkSync(file));
+};
+
+module.exports = {
+  buildFile: buildFile,
+  buildDirectory: buildDirectory,
+  watchDirectory: watchDirectory
+};

--- a/lib/sass.js
+++ b/lib/sass.js
@@ -27,6 +27,11 @@ const sassOptions = {
 };
 
 const buildFile = (path) => {
+  if (!isEntrypoint(path)) {
+    log.log('[sass] not building:', path, '(partial)');
+    return Promise.resolve(false);
+  }
+
   const opts = Object.assign({
     file: path,
     outFile: path.replace(/\.scss$/, '.css'),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   "dependencies": {
     "@frctl/fractal": "^1.0.8",
     "@frctl/nunjucks": "^1.0.1",
+    "anymatch": "^1.3.0",
+    "chokidar": "^1.6.1",
+    "fs-extra": "^1.0.0",
+    "node-sass": "^3.10.1",
     "uswds": "^0.13.1"
   }
 }


### PR DESCRIPTION
This PR adds a node-sass builder/watcher to `fractal.js` that builds SCSS entry points (not partials, which have the `_` prefix), so that we can author the standalone CSS for our components as SCSS that imports partials from the USWDS npm module. When you run `fractal build`, the CSS files are built once; when you run `fractal start`, the CSS files are built and the watcher builds again whenever the SCSS sources change.

You can see an example of how this works in [usa-button.scss], which generates [usa-button.css]. The idea is that these SCSS files are a form of documenting all of the "dependencies" of the component. Buttons are a good example of this pattern because they don't _necessarily_ depend on many other aspects of the USWDS style, like typography, grids, or table styling.

⚠️  There is one, glaring issue: **Changes to the any imported Sass file do not trigger a rebuild**. We could fix this by having the watcher do a rebuild of all entry points in the source directory when any `**/*.s[ac]ss` file changes in the working directory (including those in `node_modules`?).

[usa-button.scss]: https://github.com/18F/marigold/tree/build-sass/src/components/button/usa-button.scss
[usa-button.css]: https://github.com/18F/marigold/tree/build-sass/src/components/button/usa-button.css