### PR TITLE
Adding statuses and documentation for statuses

### DIFF
--- a/fractal.js
+++ b/fractal.js
@@ -19,6 +19,39 @@ fractal.components.engine(require('@frctl/nunjucks')({
 fractal.components.set('ext', '.njk');
 fractal.components.set('path', src + '/components');
 fractal.components.set('default.preview', '@base');
+fractal.components.set('default.status', 'hypothesis');
+fractal.components.set('statuses', {
+  hypothesis: {
+    label: "Hypothesis",
+    description: "User need has been identified, but the approach to solving the problem has not yet been decided. Team has decided to tackle this UI pattern. The pattern has been listed in the public roadmap.",
+    color: "#e31c3d"
+  },
+  proposed: {
+    label: "Proposed",
+    description: "Identifies what user need the pattern solves. Lists alternative patterns that support this user need. Includes a rendering of the design. Describes any primary or secondary research that supports this pattern",
+    color: "#fdb81e"
+  },
+  alpha: {
+    label: "Alpha",
+    description: "The pattern has passed all heuristic assessments. No secondary research that would explicitly reject the pattern has surfanced.",
+    color: "#02bfe7"
+  },
+  beta: {
+    label: "Beta",
+    description: "Pattern is generally usable, on multiple devices, for people with relatively “normal” digital literacy. Pattern works in multiple configurations with other components. First draft of documentation is written.",
+    color: "#205493"
+  },
+  recommended: {
+    label: "Recommended",
+    description: "Pattern is usable, on multiple devices, by people with multiple disabilities and pattern is documented including context of use rationale.",
+    color: "#2e8540"
+  },
+  deprecated: {
+    label: "Deprecated",
+    description: "Pattern has been removed from the pattern library, design stencils and marked deprecated in release notes.",
+    color: "#5b616b"
+  }
+});
 
 fractal.docs.set('path', src + '/docs');
 

--- a/src/components/govbanner/govbanner.config.yml
+++ b/src/components/govbanner/govbanner.config.yml
@@ -1,4 +1,5 @@
 name: Government banner
+status: hypothesis
 handle: govbanner
 preview: '@uswds'
 context:

--- a/src/components/header/header.config.yml
+++ b/src/components/header/header.config.yml
@@ -1,4 +1,5 @@
 title: Header
+status: beta
 preview: '@uswds'
 context:
   asset_path: '/assets/uswds/'

--- a/src/components/toggle/toggle.config.yml
+++ b/src/components/toggle/toggle.config.yml
@@ -1,3 +1,4 @@
 title: Toggle
+status: alpha
 context:
   question: "HAVE YOU HAD LUNCH TODAY?"

--- a/src/docs/01-index.md
+++ b/src/docs/01-index.md
@@ -1,5 +1,5 @@
 ---
-title: Marigold
+title: Marigold Overview
 ---
 
 A set of reusable components and tools for building websites and applications at 18F. The goal of Marigold is to gather and store patterns and reference materials that help every project at 18F build useful, delightful experiences. Our hope is that this will help us record what we learn and save us all time.

--- a/src/docs/03-component-status.md
+++ b/src/docs/03-component-status.md
@@ -1,0 +1,42 @@
+---
+title: Component Status
+---
+
+The component status scale is a way to indicate the level of robustness of any component or asset within the Marigold project.
+
+
+## Hypothesis
+
+- The user need has been identified, but the approach to solving the problem has not yet been decided.
+- The core team has decided to tackle this UI pattern.
+- The pattern has been listed in the public roadmap.
+
+
+## Proposed
+
+- Identifies what user need the pattern solves.
+- Lists alternative patterns that support this user need (along with reasons why the submitted pattern is the best choice).
+- Includes a rendering of the design: a wireframe, design mock-up, interaction pattern, prototype, or (link to) a finished pattern.
+- Describes any primary or secondary research that supports this pattern (include who you tested with, what kind of research you conducted, and links to any supporting documentation, including interview protocols, prototype used, and so on).
+
+## Alpha
+
+- The pattern has passed all heuristic assessments.
+- Our team hasn’t surfaced any secondary research that would explicitly reject the pattern (Alternatively: The person submitting the pattern has attached secondary research that supports it).
+
+## Beta
+
+- Pattern is generally usable, on multiple devices, for people with relatively “normal” digital literacy.
+- Pattern works in multiple configurations with other components.
+- First draft of documentation is written.
+
+## Recommended
+
+- Pattern is usable, on multiple devices, by people with multiple disabilities (blind, low vision, cognitive disabilities, motor disabilities, low language skills, low digital literacy, and more).
+- Documentation, including context of use rationale, is complete.
+- Pattern has been in beta for [period of time] and external teams report few problems using it.
+
+## Deprecated
+
+- Pattern has been removed from the pattern library and design stencils.
+- Pattern has been marked deprecated in release notes.


### PR DESCRIPTION
Added documentation for each status level and used the same status levels as described in the [USWDS](https://standards.usa.gov/about-our-work/component-maturity-scale/). 

Also added the following status for components:

- Hypothesis
- Proposed
- Alpha
- Beta
- Recommended
- Deprecated